### PR TITLE
Fix division by zero issue in SpatialAlignmentHistory.AverageRotation

### DIFF
--- a/source/MagicLeap-Tools/Code/Networking/SpatialAlignment/Objects/SpatialAlignmentHistory.cs
+++ b/source/MagicLeap-Tools/Code/Networking/SpatialAlignment/Objects/SpatialAlignmentHistory.cs
@@ -47,10 +47,18 @@ namespace MagicLeapTools
 
                 foreach (var item in rotations)
                 {
-                    x += item.x;
-                    y += item.y;
-                    z += item.z;
-                    w += item.w;
+                    if (item.w < 0)
+                    {
+                        x -= item.x;
+                        y -= item.y;
+                        z -= item.z;
+                        w -= item.w;
+                    } else {
+                        x += item.x;
+                        y += item.y;
+                        z += item.z;
+                        w += item.w;
+                    }
                 }
                 float k = 1 / Mathf.Sqrt(x * x + y * y + z * z + w * w);
                 return new Quaternion(x * k, y * k, z * k, w * k);


### PR DESCRIPTION
When averaging quaternions, sometimes the sign is reversed for the same quaternion. In current logic, it may cause a "division by zero" issue if the sum of item.x, y, z, and w is zero. To avoid it, I fixed the code so that w is guaranteed to be positive when summarizing.