### PR TITLE
Fix divide by zero issue caused by quaternion's double-cover.

### DIFF
--- a/source/MagicLeap-Tools/Code/Networking/SpatialAlignment/Objects/SpatialAlignmentHistory.cs
+++ b/source/MagicLeap-Tools/Code/Networking/SpatialAlignment/Objects/SpatialAlignmentHistory.cs
@@ -45,12 +45,20 @@ namespace MagicLeapTools
                 float z = 0;
                 float w = 0;
 
+                if (rotations.Count == 0)
+                {
+                    return Quaternion.identity;
+                }
+                Quaternion q = rotations[0];
                 foreach (var item in rotations)
                 {
-                    x += item.x;
-                    y += item.y;
-                    z += item.z;
-                    w += item.w;
+                    //double-cover correction:
+                    float dot = Quaternion.Dot(q, item);
+                    float multi = dot > 0f ? 1f : -1f;
+                    x += item.x * multi;
+                    y += item.y * multi;
+                    z += item.z * multi;
+                    w += item.w * multi;
                 }
                 float k = 1 / Mathf.Sqrt(x * x + y * y + z * z + w * w);
                 return new Quaternion(x * k, y * k, z * k, w * k);


### PR DESCRIPTION
When averaging quaternions in SpatialAlignmentHistory, it might cause a "division by zero" issue if the sum of item.x, y, z, and w is zero. It is related to a double cover problem of quaternion. Here is an example code to reproduce the issue.

```
Quaternion q1 = new Quaternion(0.007f, 0.271f, 0.005f, 0.963f);
Quaternion q2 = new Quaternion(-0.007f, -0.271f, -0.005f, -0.963f);
SpatialAlignmentHistory history = new SpatialAlignmentHistory(100);
history.rotations.Add(q1);
history.rotations.Add(q2);
var av = history.AverageRotation;
Debug.Log(av.ToString("F3"));
```

In this case, q1 and q2 are the same rotation, but sign-reversed. The sum of those quaternions is zero so it causes a division by zero issue when averaging. To avoid it, I applied a kind of normalization to quaternions as MotionUtilities.SmoothDamp does.

Please review this. Thank you.
